### PR TITLE
Compatibility with Python2.7 and Python3.X

### DIFF
--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -1,0 +1,31 @@
+name: Cropy
+ 
+on: [push]
+
+jobs:
+  build:
+    name: Python ${{ matrix.python-version}} Ubuntu
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.x', '3.x']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python version
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Pip Install Cropy
+        script: python -m pip install .
+      - name: Run Test 1
+        script: |
+                mkdir test_results
+                cropy -i test-images/church.jpg -r 300 300 -o test_results/church_300x300.jpg -s 100
+                cropy -i test-images/3people.jpg -o test_results/3people.jpg -s 100
+      - name: Upload Results
+        uses: actions/upload-artifact@v1
+        with:
+          name: cropy_test_results
+          path: test_results
+    

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.x', '3.x']
+        python-version: ['2.7', '3.8']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python version

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Pip Install Cropy
         script: python -m pip install .
       - name: Run Test 1
-        script: |
+        run: |
                 mkdir test_results
                 cropy -i test-images/church.jpg -r 300 300 -o test_results/church_300x300.jpg -s 100
                 cropy -i test-images/3people.jpg -o test_results/3people.jpg -s 100

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Pip Install Cropy
-        script: python -m pip install .
+        run: python -m pip install .
       - name: Run Test 1
         run: |
                 mkdir test_results

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -18,8 +18,8 @@ jobs:
           architecture: x64
       - name: Pip Install Cropy
         run: |
-              python -m pip install numpy scipy scikit-image Pillow
-              python -m pip install .
+              pip install numpy scipy scikit-image Pillow
+              pip install .
       - name: Run Test 1
         run: |
                 mkdir test_results

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -17,7 +17,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Pip Install Cropy
-        run: python -m pip install .
+        run: |
+              python -m pip install numpy scipy scikit-image Pillow
+              python -m pip install .
       - name: Run Test 1
         run: |
                 mkdir test_results

--- a/.github/workflows/test_cropy.yml
+++ b/.github/workflows/test_cropy.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
                 mkdir test_results
                 cropy -i test-images/church.jpg -r 300 300 -o test_results/church_300x300.jpg -s 100
-                cropy -i test-images/3people.jpg -o test_results/3people.jpg -s 100
+                cropy -i test-images/3people.jpg -r 700 300 -o test_results/3people.jpg -s 100
       - name: Upload Results
         uses: actions/upload-artifact@v1
         with:

--- a/cropy/cropy
+++ b/cropy/cropy
@@ -22,7 +22,7 @@ if __name__ == '__main__':
     (options, args) = parser.parse_args()
 
     if not options.input_image or not options.resolution:
-        print "Incorrect Usage; please use -usage"
+        print("Incorrect Usage; please use -usage")
         sys.exit(2)
     if options.verbose:
         global verbose
@@ -37,7 +37,7 @@ if __name__ == '__main__':
         input_image = options.input_image
         crop_width, crop_height = int(options.resolution[0]), int(options.resolution[1])
     except:
-        print "Incorrect Usage; please use --help"
+        print("Incorrect Usage; please use --help")
         sys.exit(2)
 
     if not options.output:
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     else:
         output = options.output
 
-    im = io.imread(input_image, as_grey=True)  # Load an image with float format
+    im = io.imread(input_image, as_gray=True)  # Load an image with float format
 
     x_offset, y_offset = entropy_crop(im, crop_width, crop_height, maxSteps)
     imfin = Image.open(input_image)


### PR DESCRIPTION
A couple of small modifications so this now works with Python3, Python2.7 has now been deprecated but the changes do not affect usage with it. Proof of both versions working is now available with added Continuous Integration via GitHub Actions which now tests both Python versions.

The included test just runs `cropy` on two of the provided example images.